### PR TITLE
Changed analog defines A0-A5

### DIFF
--- a/arm/variants/XMC1300/config/XMC1300_Boot_Kit/pins_arduino.h
+++ b/arm/variants/XMC1300/config/XMC1300_Boot_Kit/pins_arduino.h
@@ -77,12 +77,12 @@ extern uint8_t MOSI;
 extern uint8_t MISO;
 extern uint8_t SCK;
 
-#define A0   0
-#define A1   1
-#define A2   2
-#define A3   3
-#define A4   4
-#define A5   5
+#define A0   17
+#define A1   18
+#define A2   19
+#define A3   20
+#define A4   21
+#define A5   22
 
 #define PIN_SPI_SS_2  23
 


### PR DESCRIPTION
A0-A5 define the pin numbers according to mapping_port_pin[].
analogRead() needs to be changed that it accepts pin numbers as well
This ensures that digitalRead(A0) works.