### PR TITLE
Changed analog defines A0-A5

### DIFF
--- a/arm/variants/XMC1300/config/XMC1300_Sense2GoL/pins_arduino.h
+++ b/arm/variants/XMC1300/config/XMC1300_Sense2GoL/pins_arduino.h
@@ -68,8 +68,9 @@ extern uint8_t SCK;
 
 #define PIN_AREF      14
 
-#define A0   0
-#define A1   1
+//Might be wrong as mapping_port_pin[] seems to be incorrect
+#define A0   17
+#define A1   18
 
 // These 2 lines should be defined in higher level or examples
 #define CH_I A0


### PR DESCRIPTION
A0-A5 define the pin numbers according to mapping_port_pin[].
analogRead() needs to be changed that it accepts pin numbers as well
This ensures that digitalRead(A0) works.